### PR TITLE
Harden CI/CD: deploy concurrency, least-privilege workflow tokens, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 # Changes to protected branches require a review from a code owner
 # (admins may bypass). Mirrors the Maintainerr app repo.
 
-*   @ydkmlt84
-*   @enoch85
+*   @ydkmlt84 @enoch85

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for maintainerr_site.
+# Changes to protected branches require a review from a code owner
+# (admins may bypass). Mirrors the Maintainerr app repo.
+
+*   @ydkmlt84
+*   @enoch85

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,6 +14,10 @@ concurrency:
   group: build-test-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: building the site only needs to read the repo.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: npm ci + astro build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,12 @@ permissions:
   pages: write
   id-token: write
 
+# Serialize deploys so rapid merges (e.g. Dependabot auto-merge) don't race;
+# never cancel an in-progress deploy mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,10 @@ concurrency:
   group: format-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: linting only needs to read the repo.
+permissions:
+  contents: read
+
 jobs:
   prettier:
     name: prettier --check


### PR DESCRIPTION
Hardens the CI/CD setup, mirroring the security model of the `Maintainerr/Maintainerr` app repo (CODEOWNERS + admin gating, least-privilege workflow tokens).

## Changes
- **Deploy concurrency** — `deploy.yml` gets a `pages` concurrency group (`cancel-in-progress: false`) so rapid merges don't spawn racing deploys.
- **Least-privilege tokens** — `build-test.yml` and `format.yml` now declare `permissions: contents: read`, matching the app repo's workflow style (previously they inherited the default `GITHUB_TOKEN` scope).
- **CODEOWNERS** — adds `.github/CODEOWNERS` (`@ydkmlt84`, `@enoch85`) so changes to protected branches require a code-owner review, mirroring the app repo. Admins may bypass.

## Companion (settings, not in this PR)
Branch protection on `main` is updated separately to require code-owner review (see PR discussion). Deliberately **not** changed to match the app: SHA-pinning actions and per-step token scoping — the app repo uses major-version tags, so we stay consistent with it.