### PR TITLE
Privacy card at 90% opacity

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -37,7 +37,7 @@ const headingClass =
 
     <section class="px-4 max-w-4xl m-auto my-8">
       <div
-        class="bg-zinc-800 rounded-lg p-8 md:p-12 text-zinc-300 leading-relaxed"
+        class="bg-zinc-800/90 rounded-lg p-8 md:p-12 text-zinc-300 leading-relaxed"
       >
         <h1 class={`${headingClass} text-3xl md:text-4xl mb-4`}>
           Privacy Policy


### PR DESCRIPTION
Sets the privacy page content card to `bg-zinc-800/90` so the background image shows through subtly. One-line change.