### PR TITLE
Fix mobile horizontal scroll + privacy card (solid, full width)

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -35,9 +35,9 @@ const headingClass =
 
     <Menu />
 
-    <section class="px-4 max-w-4xl m-auto my-8">
+    <section class="px-4 max-w-7xl m-auto my-8">
       <div
-        class="bg-zinc-800/90 rounded-lg p-8 md:p-12 text-zinc-300 leading-relaxed"
+        class="bg-zinc-800 rounded-lg p-8 md:p-12 text-zinc-300 leading-relaxed"
       >
         <h1 class={`${headingClass} text-3xl md:text-4xl mb-4`}>
           Privacy Policy

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,3 +8,11 @@
 html {
   background-color: #000;
 }
+
+/* Prevent sideways scrolling on mobile (off-screen carousel slides, etc.).
+   `clip` clips the overflow WITHOUT creating a scroll container, so — unlike
+   `overflow-x: hidden` — it doesn't break the sticky nav. */
+html,
+body {
+  overflow-x: clip;
+}


### PR DESCRIPTION
- **Mobile horizontal scroll / off-center page:** add `overflow-x: clip` to `html`/`body`. Off-screen carousel slides (and the fixed background tracking the document width) caused ~13px of sideways scroll on narrow devices, which also shifted the centered nav off. `clip` clips it **without** creating a scroll container, so `position: sticky` keeps working.
- **Privacy card:** revert to solid `bg-zinc-800` (the 90% opacity didn't look good) and widen the section to `max-w-7xl` so the card lines up with the navbar (both `96→1344`) instead of being much narrower.