### PR TITLE
SEO: shorten OG/social title so it isn't truncated

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const {
-  title = 'Maintainerr — Automatically clean up unwatched Plex, Jellyfin & Emby media',
+  title = 'Automatically clean up unwatched Plex, Jellyfin & Emby media',
   description = 'Maintainerr is a free, self-hosted tool that finds and removes unwatched or unwanted movies and shows from Plex, Jellyfin, and Emby using powerful, customizable rules.',
   image = '/og-image.png',
 } = Astro.props


### PR DESCRIPTION
The social/OG embed title was being cut off (`…Jellyfin & E…`). Drop the redundant `Maintainerr — ` prefix — the card already shows **Maintainerr** as `og:site_name`, so it was duplicated.

- Title is now `Automatically clean up unwatched Plex, Jellyfin & Emby media` (60 chars, fits under Discord's truncation).
- Applies to `<title>`, `og:title`, and `twitter:title`.

Note: after this deploys, social platforms (Discord, etc.) cache OG data — the embed may show the old title until their cache expires or is refreshed.